### PR TITLE
fix:修复NavMeshAgent拥堵的问题

### DIFF
--- a/Assets/Scripts/Enemies/Enemies.cs
+++ b/Assets/Scripts/Enemies/Enemies.cs
@@ -7,14 +7,16 @@ using Silent.MapObject.SearchObject;
 public abstract class Enemies : MonoBehaviour
 {
     //可配置属性 
-    protected float hearing { get { return setting._hearing; } }//听力
-    protected float vision { get { return setting._vision; }  }//视力
-    protected float fleeVision { get { return setting._fleeVision; } }//逃逸视力
-    protected float patrolVision { get { return setting._patrolVision; }}
-    protected float hp { get { return setting._maxHp; } set { hp = setting._maxHp; } }//血量
-    protected float moveSpeed { get { return setting._moveSpeed; } set { moveSpeed = setting._moveSpeed; } }//移动速度
-    protected float angleSpeed { get { return setting._angleSpeed; } set { angleSpeed = setting._angleSpeed; } }//转身速度
-    protected float hearingReduceSpeed { get { return setting._hearingReduceSpeed; } }//听力记忆衰减速度
+    protected float hearing { get { return setting.hearing; } }//听力
+    protected float vision { get { return setting.vision; }  }//视力
+    protected float fleeVision { get { return setting.fleeVision; } }//逃逸视力
+    protected float patrolVision { get { return setting.patrolVision; }}
+    protected float hp { get { return setting.maxHp; } set { hp = setting.maxHp; } }//血量
+    protected float moveSpeed { get { return setting.moveSpeed; } set { moveSpeed = setting.moveSpeed; } }//移动速度
+    protected float angleSpeed { get { return setting.angleSpeed; } set { angleSpeed = setting.angleSpeed; } }//转身速度
+    protected float hearingReduceSpeed { get { return setting.hearingReduceSpeed; } }//听力记忆衰减速度
+    protected float hearingDelayClearTime { get { return setting.hearingDelayClearTime; } }
+    
 
     //字段配置表
     protected GlobalSettings globalSetting;
@@ -233,11 +235,12 @@ public abstract class Enemies : MonoBehaviour
         agent.baseOffset = 0.1f;
         agent.speed = moveSpeed;
         agent.acceleration = 2f;
-        agent.stoppingDistance = 0.25f;
+        agent.stoppingDistance = 0.3f;
         agent.autoBraking = true;
         agent.radius = 0.1f;
         agent.height = 0.2f;
-        agent.avoidancePriority = 1;
+        //agent.avoidancePriority = 1;
+        agent.avoidancePriority = Random.Range(0,99);
         agent.obstacleAvoidanceType = ObstacleAvoidanceType.HighQualityObstacleAvoidance;
 
         //下面两行是为了使用navMesh2D(即navMeshPlus)所必须做的设置，因为该脚本对navMesh的导航坐标系(xz)做了翻转(xy)，不再能使用其自身的旋转方法
@@ -309,6 +312,18 @@ public abstract class Enemies : MonoBehaviour
                 }
             }
         }
+    }
+
+    //抵达目标后，延时清除该点音量记忆
+    public void HearingDelayClear(Vector2 target)
+    {
+        soundSourceList.Remove(target);
+        StopCoroutine(nameof(DelayClear));
+        StartCoroutine(DelayClear());
+    }
+    IEnumerator DelayClear()
+    {
+        yield return new WaitForSecondsRealtime(hearingDelayClearTime);
     }
 
     //判断声音记忆List是否为空，作为排序依据

--- a/Assets/Scripts/EnemySetting.cs
+++ b/Assets/Scripts/EnemySetting.cs
@@ -4,12 +4,14 @@ using UnityEngine;
 [CreateAssetMenu]
 public class EnemySetting : ScriptableObject
 {
-    public float _hearing = 0.03f;
-    public float _vision = 5f;
-    public float _fleeVision = 10f;
-    public float _patrolVision = 10f;
-    public float _maxHp = 10f;
-    public float _moveSpeed = 0.5f;
-    public float _angleSpeed = 10f;
-    public float _hearingReduceSpeed = 0.01f;
+    public float hearing = 0.03f;
+    public float vision = 5f;
+    public float fleeVision = 10f;
+    public float patrolVision = 10f;
+    public float maxHp = 10f;
+    public float moveSpeed = 0.5f;
+    public float angleSpeed = 10f;
+    public float hearingReduceSpeed = 0.01f;
+    public float hearingReduceSpeedLevel2 = 0.02f;
+    public float hearingDelayClearTime = 2f;
 }

--- a/Assets/Scripts/PathNods.cs
+++ b/Assets/Scripts/PathNods.cs
@@ -30,7 +30,7 @@ public class PathNods : MonoBehaviour
         //Debug.Log("创建Trigger");
         gameObject.tag = "PathNod";
         triggerCreater = TriggerCreater.instance;
-        triggerCreater.AddTriggerComponent(gameObject, 1.2f);
+        triggerCreater.AddTriggerComponent(gameObject, 4f);
     }
     private void OnTriggerEnter2D(Collider2D collision)
     {

--- a/Assets/Scripts/SoundPoint.cs
+++ b/Assets/Scripts/SoundPoint.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SoundPoint : MonoBehaviour
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Enemy"))
+        {
+            collision.gameObject.GetComponent<Enemies>().HearingDelayClear(transform.position);
+        }
+    }
+
+     
+}

--- a/Assets/Scripts/SoundPoint.cs.meta
+++ b/Assets/Scripts/SoundPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7e8145cc282f49abaace5333216582b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SoundSpread.cs
+++ b/Assets/Scripts/SoundSpread.cs
@@ -139,6 +139,8 @@ public class SoundSpread : MonoBehaviour
 
         GameObject hearField = TriggerCreater.instance.AddTriggerObject(r, transform, "HearField");
         hearField.AddComponent<SoundField>();
+        GameObject hearPoint = TriggerCreater.instance.AddTriggerObject(1, transform, "HearPoint");
+        hearPoint.AddComponent<SoundPoint>();
 
     }
 


### PR DESCRIPTION
1. 初始化时随机agent的avoidancePriority，使得每个agent的优先级不同

2. 增加了pathNod的Trigger的半径使其更容易抵达，避免拥挤时被挤到外围的AI永远不能抵达终点

3. 保障agent的stoppingDistance小于上述半径，避免判定到达后在Nod的有效Trigger范围之外停止，导致无法获取NextNod的信息，也即无法继续寻路